### PR TITLE
SendTransaction API update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.qsn.api</groupId>
     <artifactId>grpc-proto</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>1.1.5-SNAPSHOT</version>
     <name>grpcProto</name>
     <packaging>jar</packaging>
 

--- a/src/main/java/org/qsn/api/rpc/grpc/proto/entity/request/SendTransactionRequest.java
+++ b/src/main/java/org/qsn/api/rpc/grpc/proto/entity/request/SendTransactionRequest.java
@@ -16,6 +16,7 @@ private static final long serialVersionUID = 0L;
     super(builder);
   }
   private SendTransactionRequest() {
+    rawTransaction_ = com.google.protobuf.ByteString.EMPTY;
   }
 
   @java.lang.Override
@@ -62,16 +63,8 @@ private static final long serialVersionUID = 0L;
             break;
           }
           case 18: {
-            org.qsn.api.rpc.grpc.proto.entity.common.transaction.TransactionDto.Builder subBuilder = null;
-            if (transaction_ != null) {
-              subBuilder = transaction_.toBuilder();
-            }
-            transaction_ = input.readMessage(org.qsn.api.rpc.grpc.proto.entity.common.transaction.TransactionDto.parser(), extensionRegistry);
-            if (subBuilder != null) {
-              subBuilder.mergeFrom(transaction_);
-              transaction_ = subBuilder.buildPartial();
-            }
 
+            rawTransaction_ = input.readBytes();
             break;
           }
           default: {
@@ -132,30 +125,15 @@ private static final long serialVersionUID = 0L;
     return getBaseRequest();
   }
 
-  public static final int TRANSACTION_FIELD_NUMBER = 2;
-  private org.qsn.api.rpc.grpc.proto.entity.common.transaction.TransactionDto transaction_;
+  public static final int RAWTRANSACTION_FIELD_NUMBER = 2;
+  private com.google.protobuf.ByteString rawTransaction_;
   /**
-   * <code>.org.qsn.protobuf.TransactionDto transaction = 2;</code>
-   * @return Whether the transaction field is set.
+   * <code>bytes rawTransaction = 2;</code>
+   * @return The rawTransaction.
    */
   @java.lang.Override
-  public boolean hasTransaction() {
-    return transaction_ != null;
-  }
-  /**
-   * <code>.org.qsn.protobuf.TransactionDto transaction = 2;</code>
-   * @return The transaction.
-   */
-  @java.lang.Override
-  public org.qsn.api.rpc.grpc.proto.entity.common.transaction.TransactionDto getTransaction() {
-    return transaction_ == null ? org.qsn.api.rpc.grpc.proto.entity.common.transaction.TransactionDto.getDefaultInstance() : transaction_;
-  }
-  /**
-   * <code>.org.qsn.protobuf.TransactionDto transaction = 2;</code>
-   */
-  @java.lang.Override
-  public org.qsn.api.rpc.grpc.proto.entity.common.transaction.TransactionDtoOrBuilder getTransactionOrBuilder() {
-    return getTransaction();
+  public com.google.protobuf.ByteString getRawTransaction() {
+    return rawTransaction_;
   }
 
   private byte memoizedIsInitialized = -1;
@@ -175,8 +153,8 @@ private static final long serialVersionUID = 0L;
     if (baseRequest_ != null) {
       output.writeMessage(1, getBaseRequest());
     }
-    if (transaction_ != null) {
-      output.writeMessage(2, getTransaction());
+    if (!rawTransaction_.isEmpty()) {
+      output.writeBytes(2, rawTransaction_);
     }
     unknownFields.writeTo(output);
   }
@@ -191,9 +169,9 @@ private static final long serialVersionUID = 0L;
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getBaseRequest());
     }
-    if (transaction_ != null) {
+    if (!rawTransaction_.isEmpty()) {
       size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(2, getTransaction());
+        .computeBytesSize(2, rawTransaction_);
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -215,11 +193,8 @@ private static final long serialVersionUID = 0L;
       if (!getBaseRequest()
           .equals(other.getBaseRequest())) return false;
     }
-    if (hasTransaction() != other.hasTransaction()) return false;
-    if (hasTransaction()) {
-      if (!getTransaction()
-          .equals(other.getTransaction())) return false;
-    }
+    if (!getRawTransaction()
+        .equals(other.getRawTransaction())) return false;
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
   }
@@ -235,10 +210,8 @@ private static final long serialVersionUID = 0L;
       hash = (37 * hash) + BASEREQUEST_FIELD_NUMBER;
       hash = (53 * hash) + getBaseRequest().hashCode();
     }
-    if (hasTransaction()) {
-      hash = (37 * hash) + TRANSACTION_FIELD_NUMBER;
-      hash = (53 * hash) + getTransaction().hashCode();
-    }
+    hash = (37 * hash) + RAWTRANSACTION_FIELD_NUMBER;
+    hash = (53 * hash) + getRawTransaction().hashCode();
     hash = (29 * hash) + unknownFields.hashCode();
     memoizedHashCode = hash;
     return hash;
@@ -378,12 +351,8 @@ private static final long serialVersionUID = 0L;
         baseRequest_ = null;
         baseRequestBuilder_ = null;
       }
-      if (transactionBuilder_ == null) {
-        transaction_ = null;
-      } else {
-        transaction_ = null;
-        transactionBuilder_ = null;
-      }
+      rawTransaction_ = com.google.protobuf.ByteString.EMPTY;
+
       return this;
     }
 
@@ -415,11 +384,7 @@ private static final long serialVersionUID = 0L;
       } else {
         result.baseRequest_ = baseRequestBuilder_.build();
       }
-      if (transactionBuilder_ == null) {
-        result.transaction_ = transaction_;
-      } else {
-        result.transaction_ = transactionBuilder_.build();
-      }
+      result.rawTransaction_ = rawTransaction_;
       onBuilt();
       return result;
     }
@@ -471,8 +436,8 @@ private static final long serialVersionUID = 0L;
       if (other.hasBaseRequest()) {
         mergeBaseRequest(other.getBaseRequest());
       }
-      if (other.hasTransaction()) {
-        mergeTransaction(other.getTransaction());
+      if (other.getRawTransaction() != com.google.protobuf.ByteString.EMPTY) {
+        setRawTransaction(other.getRawTransaction());
       }
       this.mergeUnknownFields(other.unknownFields);
       onChanged();
@@ -622,123 +587,38 @@ private static final long serialVersionUID = 0L;
       return baseRequestBuilder_;
     }
 
-    private org.qsn.api.rpc.grpc.proto.entity.common.transaction.TransactionDto transaction_;
-    private com.google.protobuf.SingleFieldBuilderV3<
-        org.qsn.api.rpc.grpc.proto.entity.common.transaction.TransactionDto, org.qsn.api.rpc.grpc.proto.entity.common.transaction.TransactionDto.Builder, org.qsn.api.rpc.grpc.proto.entity.common.transaction.TransactionDtoOrBuilder> transactionBuilder_;
+    private com.google.protobuf.ByteString rawTransaction_ = com.google.protobuf.ByteString.EMPTY;
     /**
-     * <code>.org.qsn.protobuf.TransactionDto transaction = 2;</code>
-     * @return Whether the transaction field is set.
+     * <code>bytes rawTransaction = 2;</code>
+     * @return The rawTransaction.
      */
-    public boolean hasTransaction() {
-      return transactionBuilder_ != null || transaction_ != null;
+    @java.lang.Override
+    public com.google.protobuf.ByteString getRawTransaction() {
+      return rawTransaction_;
     }
     /**
-     * <code>.org.qsn.protobuf.TransactionDto transaction = 2;</code>
-     * @return The transaction.
+     * <code>bytes rawTransaction = 2;</code>
+     * @param value The rawTransaction to set.
+     * @return This builder for chaining.
      */
-    public org.qsn.api.rpc.grpc.proto.entity.common.transaction.TransactionDto getTransaction() {
-      if (transactionBuilder_ == null) {
-        return transaction_ == null ? org.qsn.api.rpc.grpc.proto.entity.common.transaction.TransactionDto.getDefaultInstance() : transaction_;
-      } else {
-        return transactionBuilder_.getMessage();
-      }
-    }
-    /**
-     * <code>.org.qsn.protobuf.TransactionDto transaction = 2;</code>
-     */
-    public Builder setTransaction(org.qsn.api.rpc.grpc.proto.entity.common.transaction.TransactionDto value) {
-      if (transactionBuilder_ == null) {
-        if (value == null) {
-          throw new NullPointerException();
-        }
-        transaction_ = value;
-        onChanged();
-      } else {
-        transactionBuilder_.setMessage(value);
-      }
-
-      return this;
-    }
-    /**
-     * <code>.org.qsn.protobuf.TransactionDto transaction = 2;</code>
-     */
-    public Builder setTransaction(
-        org.qsn.api.rpc.grpc.proto.entity.common.transaction.TransactionDto.Builder builderForValue) {
-      if (transactionBuilder_ == null) {
-        transaction_ = builderForValue.build();
-        onChanged();
-      } else {
-        transactionBuilder_.setMessage(builderForValue.build());
-      }
-
-      return this;
-    }
-    /**
-     * <code>.org.qsn.protobuf.TransactionDto transaction = 2;</code>
-     */
-    public Builder mergeTransaction(org.qsn.api.rpc.grpc.proto.entity.common.transaction.TransactionDto value) {
-      if (transactionBuilder_ == null) {
-        if (transaction_ != null) {
-          transaction_ =
-            org.qsn.api.rpc.grpc.proto.entity.common.transaction.TransactionDto.newBuilder(transaction_).mergeFrom(value).buildPartial();
-        } else {
-          transaction_ = value;
-        }
-        onChanged();
-      } else {
-        transactionBuilder_.mergeFrom(value);
-      }
-
-      return this;
-    }
-    /**
-     * <code>.org.qsn.protobuf.TransactionDto transaction = 2;</code>
-     */
-    public Builder clearTransaction() {
-      if (transactionBuilder_ == null) {
-        transaction_ = null;
-        onChanged();
-      } else {
-        transaction_ = null;
-        transactionBuilder_ = null;
-      }
-
-      return this;
-    }
-    /**
-     * <code>.org.qsn.protobuf.TransactionDto transaction = 2;</code>
-     */
-    public org.qsn.api.rpc.grpc.proto.entity.common.transaction.TransactionDto.Builder getTransactionBuilder() {
-      
+    public Builder setRawTransaction(com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  
+      rawTransaction_ = value;
       onChanged();
-      return getTransactionFieldBuilder().getBuilder();
+      return this;
     }
     /**
-     * <code>.org.qsn.protobuf.TransactionDto transaction = 2;</code>
+     * <code>bytes rawTransaction = 2;</code>
+     * @return This builder for chaining.
      */
-    public org.qsn.api.rpc.grpc.proto.entity.common.transaction.TransactionDtoOrBuilder getTransactionOrBuilder() {
-      if (transactionBuilder_ != null) {
-        return transactionBuilder_.getMessageOrBuilder();
-      } else {
-        return transaction_ == null ?
-            org.qsn.api.rpc.grpc.proto.entity.common.transaction.TransactionDto.getDefaultInstance() : transaction_;
-      }
-    }
-    /**
-     * <code>.org.qsn.protobuf.TransactionDto transaction = 2;</code>
-     */
-    private com.google.protobuf.SingleFieldBuilderV3<
-        org.qsn.api.rpc.grpc.proto.entity.common.transaction.TransactionDto, org.qsn.api.rpc.grpc.proto.entity.common.transaction.TransactionDto.Builder, org.qsn.api.rpc.grpc.proto.entity.common.transaction.TransactionDtoOrBuilder> 
-        getTransactionFieldBuilder() {
-      if (transactionBuilder_ == null) {
-        transactionBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            org.qsn.api.rpc.grpc.proto.entity.common.transaction.TransactionDto, org.qsn.api.rpc.grpc.proto.entity.common.transaction.TransactionDto.Builder, org.qsn.api.rpc.grpc.proto.entity.common.transaction.TransactionDtoOrBuilder>(
-                getTransaction(),
-                getParentForChildren(),
-                isClean());
-        transaction_ = null;
-      }
-      return transactionBuilder_;
+    public Builder clearRawTransaction() {
+      
+      rawTransaction_ = getDefaultInstance().getRawTransaction();
+      onChanged();
+      return this;
     }
     @java.lang.Override
     public final Builder setUnknownFields(

--- a/src/main/java/org/qsn/api/rpc/grpc/proto/entity/request/SendTransactionRequestOrBuilder.java
+++ b/src/main/java/org/qsn/api/rpc/grpc/proto/entity/request/SendTransactionRequestOrBuilder.java
@@ -23,17 +23,8 @@ public interface SendTransactionRequestOrBuilder extends
   org.qsn.api.rpc.grpc.proto.entity.common.BaseRequestOrBuilder getBaseRequestOrBuilder();
 
   /**
-   * <code>.org.qsn.protobuf.TransactionDto transaction = 2;</code>
-   * @return Whether the transaction field is set.
+   * <code>bytes rawTransaction = 2;</code>
+   * @return The rawTransaction.
    */
-  boolean hasTransaction();
-  /**
-   * <code>.org.qsn.protobuf.TransactionDto transaction = 2;</code>
-   * @return The transaction.
-   */
-  org.qsn.api.rpc.grpc.proto.entity.common.transaction.TransactionDto getTransaction();
-  /**
-   * <code>.org.qsn.protobuf.TransactionDto transaction = 2;</code>
-   */
-  org.qsn.api.rpc.grpc.proto.entity.common.transaction.TransactionDtoOrBuilder getTransactionOrBuilder();
+  com.google.protobuf.ByteString getRawTransaction();
 }

--- a/src/main/java/org/qsn/api/rpc/grpc/proto/entity/request/TransactionRequests.java
+++ b/src/main/java/org/qsn/api/rpc/grpc/proto/entity/request/TransactionRequests.java
@@ -61,50 +61,47 @@ public final class TransactionRequests {
       "\n,qsn/entity/request/TransactionRequests" +
       ".proto\022\020org.qsn.protobuf\032#qsn/entity/com" +
       "mon/BaseRequest.proto\032 qsn/entity/common" +
-      "/BInteger.proto\0322qsn/entity/common/trans" +
-      "action/TransactionDto.proto\"\203\001\n\026SendTran" +
-      "sactionRequest\0222\n\013baseRequest\030\001 \001(\0132\035.or" +
-      "g.qsn.protobuf.BaseRequest\0225\n\013transactio" +
-      "n\030\002 \001(\0132 .org.qsn.protobuf.TransactionDt" +
-      "o\"k\n\034GetTransactionReceiptRequest\0222\n\013bas" +
-      "eRequest\030\001 \001(\0132\035.org.qsn.protobuf.BaseRe" +
-      "quest\022\027\n\017transactionHash\030\002 \001(\014\"d\n\025GetTra" +
-      "nsactionRequest\0222\n\013baseRequest\030\001 \001(\0132\035.o" +
-      "rg.qsn.protobuf.BaseRequest\022\027\n\017transacti" +
-      "onHash\030\002 \001(\014\"\226\001\n\032CreateRawTransferTxRequ" +
-      "est\0222\n\013baseRequest\030\001 \001(\0132\035.org.qsn.proto" +
-      "buf.BaseRequest\022\014\n\004from\030\002 \001(\014\022\n\n\002to\030\003 \001(" +
-      "\014\022*\n\006amount\030\004 \001(\0132\032.org.qsn.protobuf.BIn" +
-      "teger\"\255\001\n CreateRawDeployContractTxReque" +
-      "st\0222\n\013baseRequest\030\001 \001(\0132\035.org.qsn.protob" +
-      "uf.BaseRequest\022\016\n\006sender\030\002 \001(\014\022\024\n\014contra" +
-      "ctCode\030\003 \001(\014\022\024\n\014contractName\030\004 \001(\t\022\031\n\021co" +
-      "ntractClassName\030\005 \001(\t\"\346\001\n\033CreateRawValid" +
-      "atorTxRequest\0222\n\013baseRequest\030\001 \001(\0132\035.org" +
-      ".qsn.protobuf.BaseRequest\022\014\n\004type\030\002 \001(\010\022" +
-      "\030\n\020validatorAddress\030\003 \001(\014\022\027\n\017validatorPu" +
-      "bKey\030\004 \001(\014\022\031\n\021delegationAddress\030\005 \001(\014\022)\n" +
-      "\005stake\030\006 \001(\0132\032.org.qsn.protobuf.BInteger" +
-      "\022\014\n\004name\030\007 \001(\t\"\215\001\n\032CreateRawWithdrawTxRe" +
-      "quest\0222\n\013baseRequest\030\001 \001(\0132\035.org.qsn.pro" +
-      "tobuf.BaseRequest\022\020\n\010coinBase\030\002 \001(\014\022)\n\005v" +
-      "alue\030\003 \001(\0132\032.org.qsn.protobuf.BIntegerB-" +
-      "\n)org.qsn.api.rpc.grpc.proto.entity.requ" +
-      "estP\001b\006proto3"
+      "/BInteger.proto\"d\n\026SendTransactionReques" +
+      "t\0222\n\013baseRequest\030\001 \001(\0132\035.org.qsn.protobu" +
+      "f.BaseRequest\022\026\n\016rawTransaction\030\002 \001(\014\"k\n" +
+      "\034GetTransactionReceiptRequest\0222\n\013baseReq" +
+      "uest\030\001 \001(\0132\035.org.qsn.protobuf.BaseReques" +
+      "t\022\027\n\017transactionHash\030\002 \001(\014\"d\n\025GetTransac" +
+      "tionRequest\0222\n\013baseRequest\030\001 \001(\0132\035.org.q" +
+      "sn.protobuf.BaseRequest\022\027\n\017transactionHa" +
+      "sh\030\002 \001(\014\"\226\001\n\032CreateRawTransferTxRequest\022" +
+      "2\n\013baseRequest\030\001 \001(\0132\035.org.qsn.protobuf." +
+      "BaseRequest\022\014\n\004from\030\002 \001(\014\022\n\n\002to\030\003 \001(\014\022*\n" +
+      "\006amount\030\004 \001(\0132\032.org.qsn.protobuf.BIntege" +
+      "r\"\255\001\n CreateRawDeployContractTxRequest\0222" +
+      "\n\013baseRequest\030\001 \001(\0132\035.org.qsn.protobuf.B" +
+      "aseRequest\022\016\n\006sender\030\002 \001(\014\022\024\n\014contractCo" +
+      "de\030\003 \001(\014\022\024\n\014contractName\030\004 \001(\t\022\031\n\021contra" +
+      "ctClassName\030\005 \001(\t\"\346\001\n\033CreateRawValidator" +
+      "TxRequest\0222\n\013baseRequest\030\001 \001(\0132\035.org.qsn" +
+      ".protobuf.BaseRequest\022\014\n\004type\030\002 \001(\010\022\030\n\020v" +
+      "alidatorAddress\030\003 \001(\014\022\027\n\017validatorPubKey" +
+      "\030\004 \001(\014\022\031\n\021delegationAddress\030\005 \001(\014\022)\n\005sta" +
+      "ke\030\006 \001(\0132\032.org.qsn.protobuf.BInteger\022\014\n\004" +
+      "name\030\007 \001(\t\"\215\001\n\032CreateRawWithdrawTxReques" +
+      "t\0222\n\013baseRequest\030\001 \001(\0132\035.org.qsn.protobu" +
+      "f.BaseRequest\022\020\n\010coinBase\030\002 \001(\014\022)\n\005value" +
+      "\030\003 \001(\0132\032.org.qsn.protobuf.BIntegerB-\n)or" +
+      "g.qsn.api.rpc.grpc.proto.entity.requestP" +
+      "\001b\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
         new com.google.protobuf.Descriptors.FileDescriptor[] {
           org.qsn.api.rpc.grpc.proto.entity.common.BaseRequestOuterClass.getDescriptor(),
           org.qsn.api.rpc.grpc.proto.entity.common.BIntegerOuterClass.getDescriptor(),
-          org.qsn.api.rpc.grpc.proto.entity.common.transaction.TransactionDtoOuterClass.getDescriptor(),
         });
     internal_static_org_qsn_protobuf_SendTransactionRequest_descriptor =
       getDescriptor().getMessageTypes().get(0);
     internal_static_org_qsn_protobuf_SendTransactionRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_org_qsn_protobuf_SendTransactionRequest_descriptor,
-        new java.lang.String[] { "BaseRequest", "Transaction", });
+        new java.lang.String[] { "BaseRequest", "RawTransaction", });
     internal_static_org_qsn_protobuf_GetTransactionReceiptRequest_descriptor =
       getDescriptor().getMessageTypes().get(1);
     internal_static_org_qsn_protobuf_GetTransactionReceiptRequest_fieldAccessorTable = new
@@ -143,7 +140,6 @@ public final class TransactionRequests {
         new java.lang.String[] { "BaseRequest", "CoinBase", "Value", });
     org.qsn.api.rpc.grpc.proto.entity.common.BaseRequestOuterClass.getDescriptor();
     org.qsn.api.rpc.grpc.proto.entity.common.BIntegerOuterClass.getDescriptor();
-    org.qsn.api.rpc.grpc.proto.entity.common.transaction.TransactionDtoOuterClass.getDescriptor();
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/src/main/proto/qsn/entity/request/TransactionRequests.proto
+++ b/src/main/proto/qsn/entity/request/TransactionRequests.proto
@@ -7,11 +7,10 @@ package org.qsn.protobuf;
 
 import "qsn/entity/common/BaseRequest.proto";
 import "qsn/entity/common/BInteger.proto";
-import "qsn/entity/common/transaction/TransactionDto.proto";
 
 message SendTransactionRequest{
     BaseRequest baseRequest = 1;
-    TransactionDto transaction = 2;
+    bytes rawTransaction = 2;
 }
 
 message GetTransactionReceiptRequest{

--- a/src/main/python/qsn/entity/request/TransactionRequests_pb2.py
+++ b/src/main/python/qsn/entity/request/TransactionRequests_pb2.py
@@ -13,7 +13,6 @@ _sym_db = _symbol_database.Default()
 
 from qsn.entity.common import BaseRequest_pb2 as qsn_dot_entity_dot_common_dot_BaseRequest__pb2
 from qsn.entity.common import BInteger_pb2 as qsn_dot_entity_dot_common_dot_BInteger__pb2
-from qsn.entity.common.transaction import TransactionDto_pb2 as qsn_dot_entity_dot_common_dot_transaction_dot_TransactionDto__pb2
 
 
 DESCRIPTOR = _descriptor.FileDescriptor(
@@ -22,9 +21,9 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   syntax='proto3',
   serialized_options=b'\n)org.qsn.api.rpc.grpc.proto.entity.requestP\001',
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n,qsn/entity/request/TransactionRequests.proto\x12\x10org.qsn.protobuf\x1a#qsn/entity/common/BaseRequest.proto\x1a qsn/entity/common/BInteger.proto\x1a\x32qsn/entity/common/transaction/TransactionDto.proto\"\x83\x01\n\x16SendTransactionRequest\x12\x32\n\x0b\x62\x61seRequest\x18\x01 \x01(\x0b\x32\x1d.org.qsn.protobuf.BaseRequest\x12\x35\n\x0btransaction\x18\x02 \x01(\x0b\x32 .org.qsn.protobuf.TransactionDto\"k\n\x1cGetTransactionReceiptRequest\x12\x32\n\x0b\x62\x61seRequest\x18\x01 \x01(\x0b\x32\x1d.org.qsn.protobuf.BaseRequest\x12\x17\n\x0ftransactionHash\x18\x02 \x01(\x0c\"d\n\x15GetTransactionRequest\x12\x32\n\x0b\x62\x61seRequest\x18\x01 \x01(\x0b\x32\x1d.org.qsn.protobuf.BaseRequest\x12\x17\n\x0ftransactionHash\x18\x02 \x01(\x0c\"\x96\x01\n\x1a\x43reateRawTransferTxRequest\x12\x32\n\x0b\x62\x61seRequest\x18\x01 \x01(\x0b\x32\x1d.org.qsn.protobuf.BaseRequest\x12\x0c\n\x04\x66rom\x18\x02 \x01(\x0c\x12\n\n\x02to\x18\x03 \x01(\x0c\x12*\n\x06\x61mount\x18\x04 \x01(\x0b\x32\x1a.org.qsn.protobuf.BInteger\"\xad\x01\n CreateRawDeployContractTxRequest\x12\x32\n\x0b\x62\x61seRequest\x18\x01 \x01(\x0b\x32\x1d.org.qsn.protobuf.BaseRequest\x12\x0e\n\x06sender\x18\x02 \x01(\x0c\x12\x14\n\x0c\x63ontractCode\x18\x03 \x01(\x0c\x12\x14\n\x0c\x63ontractName\x18\x04 \x01(\t\x12\x19\n\x11\x63ontractClassName\x18\x05 \x01(\t\"\xe6\x01\n\x1b\x43reateRawValidatorTxRequest\x12\x32\n\x0b\x62\x61seRequest\x18\x01 \x01(\x0b\x32\x1d.org.qsn.protobuf.BaseRequest\x12\x0c\n\x04type\x18\x02 \x01(\x08\x12\x18\n\x10validatorAddress\x18\x03 \x01(\x0c\x12\x17\n\x0fvalidatorPubKey\x18\x04 \x01(\x0c\x12\x19\n\x11\x64\x65legationAddress\x18\x05 \x01(\x0c\x12)\n\x05stake\x18\x06 \x01(\x0b\x32\x1a.org.qsn.protobuf.BInteger\x12\x0c\n\x04name\x18\x07 \x01(\t\"\x8d\x01\n\x1a\x43reateRawWithdrawTxRequest\x12\x32\n\x0b\x62\x61seRequest\x18\x01 \x01(\x0b\x32\x1d.org.qsn.protobuf.BaseRequest\x12\x10\n\x08\x63oinBase\x18\x02 \x01(\x0c\x12)\n\x05value\x18\x03 \x01(\x0b\x32\x1a.org.qsn.protobuf.BIntegerB-\n)org.qsn.api.rpc.grpc.proto.entity.requestP\x01\x62\x06proto3'
+  serialized_pb=b'\n,qsn/entity/request/TransactionRequests.proto\x12\x10org.qsn.protobuf\x1a#qsn/entity/common/BaseRequest.proto\x1a qsn/entity/common/BInteger.proto\"d\n\x16SendTransactionRequest\x12\x32\n\x0b\x62\x61seRequest\x18\x01 \x01(\x0b\x32\x1d.org.qsn.protobuf.BaseRequest\x12\x16\n\x0erawTransaction\x18\x02 \x01(\x0c\"k\n\x1cGetTransactionReceiptRequest\x12\x32\n\x0b\x62\x61seRequest\x18\x01 \x01(\x0b\x32\x1d.org.qsn.protobuf.BaseRequest\x12\x17\n\x0ftransactionHash\x18\x02 \x01(\x0c\"d\n\x15GetTransactionRequest\x12\x32\n\x0b\x62\x61seRequest\x18\x01 \x01(\x0b\x32\x1d.org.qsn.protobuf.BaseRequest\x12\x17\n\x0ftransactionHash\x18\x02 \x01(\x0c\"\x96\x01\n\x1a\x43reateRawTransferTxRequest\x12\x32\n\x0b\x62\x61seRequest\x18\x01 \x01(\x0b\x32\x1d.org.qsn.protobuf.BaseRequest\x12\x0c\n\x04\x66rom\x18\x02 \x01(\x0c\x12\n\n\x02to\x18\x03 \x01(\x0c\x12*\n\x06\x61mount\x18\x04 \x01(\x0b\x32\x1a.org.qsn.protobuf.BInteger\"\xad\x01\n CreateRawDeployContractTxRequest\x12\x32\n\x0b\x62\x61seRequest\x18\x01 \x01(\x0b\x32\x1d.org.qsn.protobuf.BaseRequest\x12\x0e\n\x06sender\x18\x02 \x01(\x0c\x12\x14\n\x0c\x63ontractCode\x18\x03 \x01(\x0c\x12\x14\n\x0c\x63ontractName\x18\x04 \x01(\t\x12\x19\n\x11\x63ontractClassName\x18\x05 \x01(\t\"\xe6\x01\n\x1b\x43reateRawValidatorTxRequest\x12\x32\n\x0b\x62\x61seRequest\x18\x01 \x01(\x0b\x32\x1d.org.qsn.protobuf.BaseRequest\x12\x0c\n\x04type\x18\x02 \x01(\x08\x12\x18\n\x10validatorAddress\x18\x03 \x01(\x0c\x12\x17\n\x0fvalidatorPubKey\x18\x04 \x01(\x0c\x12\x19\n\x11\x64\x65legationAddress\x18\x05 \x01(\x0c\x12)\n\x05stake\x18\x06 \x01(\x0b\x32\x1a.org.qsn.protobuf.BInteger\x12\x0c\n\x04name\x18\x07 \x01(\t\"\x8d\x01\n\x1a\x43reateRawWithdrawTxRequest\x12\x32\n\x0b\x62\x61seRequest\x18\x01 \x01(\x0b\x32\x1d.org.qsn.protobuf.BaseRequest\x12\x10\n\x08\x63oinBase\x18\x02 \x01(\x0c\x12)\n\x05value\x18\x03 \x01(\x0b\x32\x1a.org.qsn.protobuf.BIntegerB-\n)org.qsn.api.rpc.grpc.proto.entity.requestP\x01\x62\x06proto3'
   ,
-  dependencies=[qsn_dot_entity_dot_common_dot_BaseRequest__pb2.DESCRIPTOR,qsn_dot_entity_dot_common_dot_BInteger__pb2.DESCRIPTOR,qsn_dot_entity_dot_common_dot_transaction_dot_TransactionDto__pb2.DESCRIPTOR,])
+  dependencies=[qsn_dot_entity_dot_common_dot_BaseRequest__pb2.DESCRIPTOR,qsn_dot_entity_dot_common_dot_BInteger__pb2.DESCRIPTOR,])
 
 
 
@@ -45,9 +44,9 @@ _SENDTRANSACTIONREQUEST = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='transaction', full_name='org.qsn.protobuf.SendTransactionRequest.transaction', index=1,
-      number=2, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
+      name='rawTransaction', full_name='org.qsn.protobuf.SendTransactionRequest.rawTransaction', index=1,
+      number=2, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"",
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
@@ -63,8 +62,8 @@ _SENDTRANSACTIONREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=190,
-  serialized_end=321,
+  serialized_start=137,
+  serialized_end=237,
 )
 
 
@@ -102,8 +101,8 @@ _GETTRANSACTIONRECEIPTREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=323,
-  serialized_end=430,
+  serialized_start=239,
+  serialized_end=346,
 )
 
 
@@ -141,8 +140,8 @@ _GETTRANSACTIONREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=432,
-  serialized_end=532,
+  serialized_start=348,
+  serialized_end=448,
 )
 
 
@@ -194,8 +193,8 @@ _CREATERAWTRANSFERTXREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=535,
-  serialized_end=685,
+  serialized_start=451,
+  serialized_end=601,
 )
 
 
@@ -254,8 +253,8 @@ _CREATERAWDEPLOYCONTRACTTXREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=688,
-  serialized_end=861,
+  serialized_start=604,
+  serialized_end=777,
 )
 
 
@@ -328,8 +327,8 @@ _CREATERAWVALIDATORTXREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=864,
-  serialized_end=1094,
+  serialized_start=780,
+  serialized_end=1010,
 )
 
 
@@ -374,12 +373,11 @@ _CREATERAWWITHDRAWTXREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1097,
-  serialized_end=1238,
+  serialized_start=1013,
+  serialized_end=1154,
 )
 
 _SENDTRANSACTIONREQUEST.fields_by_name['baseRequest'].message_type = qsn_dot_entity_dot_common_dot_BaseRequest__pb2._BASEREQUEST
-_SENDTRANSACTIONREQUEST.fields_by_name['transaction'].message_type = qsn_dot_entity_dot_common_dot_transaction_dot_TransactionDto__pb2._TRANSACTIONDTO
 _GETTRANSACTIONRECEIPTREQUEST.fields_by_name['baseRequest'].message_type = qsn_dot_entity_dot_common_dot_BaseRequest__pb2._BASEREQUEST
 _GETTRANSACTIONREQUEST.fields_by_name['baseRequest'].message_type = qsn_dot_entity_dot_common_dot_BaseRequest__pb2._BASEREQUEST
 _CREATERAWTRANSFERTXREQUEST.fields_by_name['baseRequest'].message_type = qsn_dot_entity_dot_common_dot_BaseRequest__pb2._BASEREQUEST


### PR DESCRIPTION
API SendTransaction update, use rlp encoded raw byte array of transaction instead of Transaction object to avoid null property be transferred to empty object.